### PR TITLE
Add PromptTrace to CTFs & Challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Adversarial prompt datasets-both text-only and multimodal-designed to bypass saf
 - [AI GOAT](https://github.com/dhammon/ai-goat) [![GitHub Repo stars](https://img.shields.io/github/stars/dhammon/ai-goat?logo=github&label=&style=social)](https://github.com/dhammon/ai-goat) - Vulnerable LLM CTF challenges for learning AI security.
 - [Damn Vulnerable LLM Agent](https://github.com/ReversecLabs/damn-vulnerable-llm-agent) [![GitHub Repo stars](https://img.shields.io/github/stars/ReversecLabs/damn-vulnerable-llm-agent?logo=github&label=&style=social)](https://github.com/ReversecLabs/damn-vulnerable-llm-agent)
 - [AI Red Teaming Playground Labs - Microsoft](https://github.com/microsoft/AI-Red-Teaming-Playground-Labs) [![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/AI-Red-Teaming-Playground-Labs?logo=github&label=&style=social)](https://github.com/microsoft/AI-Red-Teaming-Playground-Labs) - Self-hostable environment with 12 challenges (direct/indirect prompt injection, metaprompt extraction, Crescendo multi-turn, guardrail bypass).
+- [PromptTrace](https://prompttrace.airedlab.com/) - Interactive AI security training platform with 7 attack labs, 15-level Gauntlet, and real-time Context Trace visualization for practicing prompt injection, defense bypass, and tool abuse against real LLMs.
 
 ### Bespoke
 - [Trail of Bits - AI/ML Security & Safety Training](https://www.trailofbits.com/services/software-assurance/ai-ml/) - Courses on AI failure modes, adversarial attacks, data provenance, pipeline threats, and mitigation.


### PR DESCRIPTION
## Summary

- Adds [PromptTrace](https://prompttrace.airedlab.com/) to the **CTFs & Challenges** subsection under **Training**.
- PromptTrace is an interactive AI security training platform featuring 7 attack labs, a 15-level Gauntlet, and real-time Context Trace visualization. It lets practitioners practice prompt injection, defense bypass, and tool abuse against real LLMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)