### PR TITLE
Add Pipelock — agent firewall with MCP scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 ### Agent Tooling and MCP Security
 *Scan/audit MCP servers & client configs; detect tool poisoning, unsafe flows; constrain tool access with least-privilege and audit trails.*
 
+- **[Pipelock](https://github.com/luckyPipewrench/pipelock)** [![GitHub Repo stars](https://img.shields.io/github/stars/luckyPipewrench/pipelock?logo=github&label=&style=social)](https://github.com/luckyPipewrench/pipelock) - Application-layer firewall for AI agents: egress proxy with 9-layer scanner pipeline (DLP, SSRF, entropy), bidirectional MCP proxy with tool poisoning detection, and workspace integrity monitoring. Single Go binary, zero runtime deps.
+
 #### Honeypots & Deception (MCP/LLM)
 
 - **[Beelzebub](https://github.com/mariocandela/beelzebub)** [![GitHub Repo stars](https://img.shields.io/github/stars/mariocandela/beelzebub?logo=github&label=&style=social)](https://github.com/mariocandela/beelzebub) - Beelzebub is a honeypot framework designed to provide a secure environment for detecting and analyzing cyber attacks. It offers a low code approach for easy implementation and uses AI to mimic the behavior of a high-interaction honeypot.


### PR DESCRIPTION
Adds [Pipelock](https://github.com/luckyPipewrench/pipelock) to the **Agent Tooling and MCP Security** section.

Pipelock is an application-layer firewall for AI agents — a single Go binary that sits between agents and the network, scanning all HTTP and MCP traffic through a 9-layer pipeline (DLP, SSRF, prompt injection, entropy, tool poisoning detection, etc.).

**Why this section:** Pipelock scans/audits MCP traffic bidirectionally, detects tool poisoning and rug-pull changes, and enforces pre-execution tool call policies — core to the section's focus on constraining tool access and detecting unsafe flows.

**Alternative placement:** Could also fit under "Gateways & Policy Proxies" given its egress proxy and DLP filtering capabilities. Happy to move it there if preferred.