### PR TITLE
Add AstraCipher to Agent Tooling / Servers & Dev tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 #### Servers & Dev tooling
 - **[PortSwigger - MCP Server](https://github.com/PortSwigger/mcp-server)** [![GitHub Repo stars](https://img.shields.io/github/stars/PortSwigger/mcp-server?logo=github&label=&style=social)](https://github.com/PortSwigger/mcp-server)
 - **[ToolHive](https://github.com/stacklok/toolhive)** [![GitHub Repo stars](https://img.shields.io/github/stars/stacklok/toolhive?logo=github&label=&style=social)](https://github.com/stacklok/toolhive) - MCP server orchestrator for desktop, CLI, and Kubernetes Operator: discover and deploy servers in isolated containers with restricted permissions, manage secrets, use an optional egress proxy, auto-configure popular MCP clients (e.g., GitHub Copilot, Cursor), and manage at scale via CRDs/registry.
+- **[AstraCipher](https://github.com/san-techie21/astracipher)** [![GitHub Repo stars](https://img.shields.io/github/stars/san-techie21/astracipher?logo=github&label=&style=social)](https://github.com/san-techie21/astracipher) - Cryptographic identity protocol for AI agents using W3C DIDs, Verifiable Credentials, and NIST post-quantum cryptography (ML-DSA-65 FIPS 204). MCP Server provides capability-bounded tool authorization, trust chain verification, and hybrid PQC signatures for secure agent-to-tool interactions.
 
 ### Execution Sandboxing for Agent Code
 *Run untrusted or LLM-triggered code in isolated sandboxes (FS/network/process limits) to contain RCE and reduce blast radius.*


### PR DESCRIPTION
## Add AstraCipher to Agent Tooling / Servers & Dev tooling

### What it does
[AstraCipher](https://github.com/san-techie21/astracipher) is an open-source cryptographic identity protocol for AI agents, added to the **Servers & Dev tooling** subsection under **Agent Tooling and MCP Security**. It provides:

- **W3C DID-based identity** (`did:astracipher:*`) for self-sovereign agent identification
- **W3C Verifiable Credentials** encoding capabilities, permissions, trust levels, and rate limits
- **NIST post-quantum cryptography** (ML-DSA-65 FIPS 204 + ECDSA P-256 hybrid signatures)
- **Native MCP Server** with credential-verified tool authorization at every tool boundary
- **A2A Protocol Adapter** for agent-to-agent peer verification
- **Trust chain delegation** with monotonic capability attenuation

### Why this section
AstraCipher is an MCP Server that addresses agent identity and secure tool access — directly aligned with the section description: *"Scan/audit MCP servers & client configs; detect tool poisoning, unsafe flows; constrain tool access with least-privilege and audit trails."*

It specifically addresses OWASP's #3 risk for agentic applications (ASI03: Identity & Access Abuse) and is submitted to the NIST NCCoE AI Agent Identity project.

### Links
- npm: [@astracipher/core](https://www.npmjs.com/package/@astracipher/core)
- PyPI: [astracipher](https://pypi.org/project/astracipher/)
- Website: [astracipher.com](https://astracipher.com)
- 67 tests passing across TypeScript and Python implementations
