### PR TITLE
Add PIC Standard to Agentic Systems section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - [OWASP - State of Agentic AI Security and Governance](https://genai.owasp.org/resource/state-of-agentic-ai-security-and-governance-1-0/)
 - [CSA - Secure Agentic System Design: A Trait-Based Approach](https://cloudsecurityalliance.org/artifacts/secure-agentic-system-design)
 - [CSA - Agentic AI Identity & Access Management](https://cloudsecurityalliance.org/artifacts/agentic-ai-identity-and-access-management-a-new-approach) - 08/25
+- [PIC Standard](https://github.com/madeinplutofabio/pic-standard) – Local-first protocol for provenance & intent verification before agent actions (fail-closed, verifiable evidence via hashes/signatures). MCP, LangGraph, OpenClaw, Cordum ready.
 
 ### Threat Modeling
 


### PR DESCRIPTION
Adds PIC Standard: open-source (Apache 2.0) protocol for safe agentic AI. Forces agents to declare intent + impact, back claims with verifiable provenance/evidence, and fail closed on mismatch. Local-first, no cloud. Integrates with LangGraph, OpenClaw, MCP.

Fits under Agentic Systems (Standards, Governance & Patterns) as a governance/verification tool for agent actions.