### PR TITLE
Add Breaking Agent Backbones paper (ICLR 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,8 @@ Adversarial prompt datasets-both text-only and multimodal-designed to bypass saf
 
 **[Purple Llama – CyberSecEval](https://github.com/meta-llama/PurpleLlama/tree/main/CybersecurityBenchmarks)** [![GitHub Repo stars](https://img.shields.io/github/stars/meta-llama/PurpleLlama?logo=github&label=&style=social)](https://github.com/meta-llama/PurpleLlama) - evaluates models’ propensity to assist cyber-offense (exploit/malware) and to generate insecure code; graded-risk tasks with a reproducible harness. **Best for:** dangerous-capability / misuse-risk scoring (text/IDE, non-agent).
 
+- **[b³ – Breaking Agent Backbones](https://arxiv.org/abs/2510.22620)** - benchmark evaluating the security of backbone LLMs powering AI agents; 194,331 crowdsourced adversarial attacks across 34 models; introduces "threat snapshots" to identify where LLM vulnerabilities propagate to agent-level risks; finds reasoning capability (not model size) correlates with security. [ICLR 2026] [arXiv](https://arxiv.org/abs/2510.22620)
+
 ### **Prompt Injection & Jailbreak Detection**
 **Purpose**: Evaluates resistance to prompt-injection and jailbreak attempts in chat/RAG/agent contexts.  
 **NIST AI RMF Alignment**: **Measure, Manage**

--- a/Research_Papers.md
+++ b/Research_Papers.md
@@ -3,10 +3,17 @@
 A curated list of recent research relevant to AI security.
 
 ## Table of Contents
+- [February 2026](#february-2026)
 - [August 2025](#august-2025)
 - [July 2025](#july-2025)
 - [June 2025](#june-2025)
 - [May 2025](#may-2025)
+
+## February 2026
+
+- 📖 **[Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents](https://arxiv.org/abs/2510.22620)** — Introduces "threat snapshots" to identify where backbone LLM vulnerabilities propagate to agent-level risks; the b³ benchmark evaluates 34 LLMs against 194,331 crowdsourced adversarial attacks and finds reasoning capability (not model size) correlates with security. [ICLR 2026]
+
+---
 
 ## August 2025
 


### PR DESCRIPTION
Our work recently has been accepted to ICLR and I believe it could be of interest!

The MR adds the **b³ benchmark** from the paper [Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents](https://arxiv.org/abs/2510.22620) to the Agent Misuse & Harm Induction section and the paper to the paper list.

**What the benchmark does:** Introduces "threat snapshots" — a framework identifying specific execution points where LLM vulnerabilities manifest and propagate to agent-level risks. b³ is built from 194,331 crowdsourced adversarial attacks, evaluating 34 LLMs. Benchmark, dataset, and evaluation code are publicly released and can be used to evaluate security vulnerabilities of newly released Large Language Models.

Thanks for reviewing!