### PR TITLE
Add ATR (Agent Threat Rules) to Agentic Systems section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - [OWASP - State of Agentic AI Security and Governance](https://genai.owasp.org/resource/state-of-agentic-ai-security-and-governance-1-0/)
 - [CSA - Secure Agentic System Design: A Trait-Based Approach](https://cloudsecurityalliance.org/artifacts/secure-agentic-system-design)
 - [CSA - Agentic AI Identity & Access Management](https://cloudsecurityalliance.org/artifacts/agentic-ai-identity-and-access-management-a-new-approach) - 08/25
+- [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — Open-source detection rules standard for AI agent threats (108 rules, 9 categories). Adopted by Cisco AI Defense. OWASP 10/10 coverage. MIT licensed.
 
 ### Threat Modeling
 


### PR DESCRIPTION
108 open-source detection rules for AI agent threats. Shipped in Cisco AI Defense ([PR #79](https://github.com/cisco-ai-defense/skill-scanner/pull/79)). 53K+ skills scanned, 0% FP. [agentthreatrule.org](https://agentthreatrule.org)