### PR TITLE
Add tool-output-mimicry (single-primitive prompt-injection reproducer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 #### Prompt-injection test suites
 - **[Promptmap](https://github.com/utkusen/promptmap)** [![GitHub Repo stars](https://img.shields.io/github/stars/utkusen/promptmap?logo=github&label=&style=social)](https://github.com/utkusen/promptmap)
 - **[Giskard](https://github.com/Giskard-AI/giskard)** [![GitHub Repo stars](https://img.shields.io/github/stars/Giskard-AI/giskard?logo=github&label=&style=social)](https://github.com/Giskard-AI/giskard)
+- **[tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry)** [![GitHub Repo stars](https://img.shields.io/github/stars/314-ia/tool-output-mimicry?logo=github&label=&style=social)](https://github.com/314-ia/tool-output-mimicry) — Single-primitive reproducer: bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at [doi.org/10.5281/zenodo.19794072](https://doi.org/10.5281/zenodo.19794072).
 
 #### Data-leakage/secret-exfil test suites
 - **[garak](https://github.com/NVIDIA/garak)** [![GitHub Repo stars](https://img.shields.io/github/stars/NVIDIA/garak?logo=github&label=&style=social)](https://github.com/NVIDIA/garak)


### PR DESCRIPTION
## Summary

Adds [`314-ia/tool-output-mimicry`](https://github.com/314-ia/tool-output-mimicry) under **Tools → Red-Teaming Harnesses & Automated Security Testing → Prompt-injection test suites**.

## Why this fits the section

It is a single-primitive reproducer for *Tool Output Mimicry* — a refinement of indirect prompt injection (Greshake et al., 2023) specialised for the inter-agent trust boundary. Companion paper documents the threat model, the four-layer defense it bypasses, and the empirical capture against the OWASP FinBot CTF:

> Brana, J. P. (2026). *Tool Output Mimicry: Bypassing Multi-Layer Agentic AI Defenses via Upstream-Agent Impersonation in User-Controlled Fields.* Zenodo. [doi:10.5281/zenodo.19794072](https://doi.org/10.5281/zenodo.19794072) (CC BY 4.0).

## What ships in the repo

- Reference implementation of the primitive (`UpstreamAgentImpersonation`, `generate_stego_html`)
- End-to-end FinBot CTF reproducer with a `--dry-run` smoke path (zero credentials, CI-runnable)
- 24 unit tests passing on Python 3.10–3.13 (CI matrix green)
- Verbatim live-capture transcript from a freshly-registered CTF account (re-validated 2026-04-27)
- Two Zenodo DOIs (paper + software) and a Software Heritage SWHID for permanent archival

## Style compliance

- One line, em-dash separator, neutral tone — matches CONTRIBUTING.md
- Stars badge in the same format as the existing `Promptmap` and `Giskard` entries
- Added at the end of the subsection (no strict alphabetical convention observed in the section)

## License

By submitting this PR I agree to CC0 1.0 per CONTRIBUTING.md.