### PR TITLE
Add Agent-Wiz to Integrated platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 
 #### Integrated platforms
 - **[AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard)** [![GitHub Repo stars](https://img.shields.io/github/stars/Tencent/AI-Infra-Guard?logo=github&label=&style=social)](https://github.com/Tencent/AI-Infra-Guard) - AI red-teaming platform: AI infra vulnerability scan (30+ components, ~400 CVEs), MCP server risk scan (9 categories), and jailbreak evaluation; web UI + Docker quick start.
+- **[Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz)** [![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?logo=github&label=&style=social)](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI that extracts agentic workflows from LangChain, LangGraph, CrewAI, and AutoGen and runs automated threat modeling against the resulting graphs.
 
 #### Prompt-injection test suites
 - **[Promptmap](https://github.com/utkusen/promptmap)** [![GitHub Repo stars](https://img.shields.io/github/stars/utkusen/promptmap?logo=github&label=&style=social)](https://github.com/utkusen/promptmap)


### PR DESCRIPTION
Adds [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) (373⭐, MIT, on PyPI) under **Red-Teaming Harnesses & Automated Security Testing → Integrated platforms**, alongside AI-Infra-Guard.

Agent-Wiz is a Python CLI that parses agentic workflows from LangChain / LangGraph / CrewAI / AutoGen and runs automated threat modeling on them — fits the "integrated platform" framing and complements the existing entry which focuses on infrastructure scanning. Output is a visualized workflow graph with mapped attack surfaces.