### PR TITLE
Add Aigis to Prompt-Injection Detection & Mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 ### Prompt-Injection Detection & Mitigation
 *Detect and stop prompt-injection (direct/indirect) across inputs, context, and outputs; filter hostile content before it reaches tools or models.*
 
-- *(none from your current list yet)* -
+- **[Aigis](https://github.com/killertcell428/aigis)** [![GitHub Repo stars](https://img.shields.io/github/stars/killertcell428/aigis?logo=github&label=&style=social)](https://github.com/killertcell428/aigis) – Zero-dependency Python firewall for AI agents. 180+ patterns across OWASP LLM Top 10 plus 7 published-paper modules (Mirror, StruQ, MI9 goal-conditioned FSM, MemoryGraft, MSB MCP scanning, RAG context filter, AdvJudge-Zero); 44 compliance templates (US/CN/JP/EU); deploys as library, Docker sidecar, or CLI.
 
 ### Jailbreak & Policy Enforcement (Guardrails)
 *Enforce safety policies and block jailbreaks at runtime via rules/validators/DSLs, with optional human-in-the-loop for sensitive actions.*


### PR DESCRIPTION
Adds [Aigis](https://github.com/killertcell428/aigis) as the first entry under **Tools → Prompt-Injection Detection & Mitigation**. The section currently shows *"(none from your current list yet)"*.

### Why it fits this section

Aigis is a zero-dependency Python firewall for LLMs and AI agents, focused on detecting and stopping prompt injection (direct and indirect) before it reaches tools or models — exactly the section's stated purpose.

- **180+ detection patterns** across OWASP LLM Top 10 (prompt injection, jailbreak, PII, exfiltration, judge manipulation, etc.)
- **7 published papers implemented zero-dep** (each independently usable):
  - Mirror Design Pattern (arxiv:2603.11875)
  - StruQ + LLMail-Inject (structured-prompt input separation)
  - MI9 goal-conditioned FSM (arxiv:2508.03858)
  - MemoryGraft defence (arxiv:2512.16962)
  - MSB 3-stage MCP scanning (arxiv:2510.15994)
  - DataFilter + RAGDefender (RAG context filter)
  - AdvJudge-Zero (judge-manipulation detection)
- **44 compliance templates** across US/CN/JP/EU regulatory frameworks
- **Three deployment modes** — Python library, Docker sidecar (`docker run -p 8080:8080 ghcr.io/killertcell428/aigis`), or CLI
- **940+ tests passing**, [v1.0.0 released 2026-05-07](https://github.com/killertcell428/aigis/releases/tag/v1.0.0), Apache-2.0

Happy to rephrase or move it (e.g., split mentions into Jailbreak & Policy Enforcement / Agent Tooling and MCP Security if you'd prefer multiple references) — let me know.