### PR TITLE
feat: add misp-mcp-server to Servers & Dev tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 #### Servers & Dev tooling
 
 - **[PortSwigger - MCP Server](https://github.com/PortSwigger/mcp-server)** [![GitHub Repo stars](https://img.shields.io/github/stars/PortSwigger/mcp-server?logo=github&label=&style=social)](https://github.com/PortSwigger/mcp-server)
+- **[misp-mcp-server](https://github.com/ppcvote/misp-mcp-server)** [![GitHub Repo stars](https://img.shields.io/github/stars/ppcvote/misp-mcp-server?logo=github&label=&style=social)](https://github.com/ppcvote/misp-mcp-server) - MISP (Malware Information Sharing Platform) MCP server with built-in prompt-injection defense via prompt-defense-audit. 8 read-only threat-intel tools; scans every MISP response for adversarial seeding before LLM exposure. Tracks [MISP/MISP#10745](https://github.com/MISP/MISP/issues/10745).
 - **[ToolHive](https://github.com/stacklok/toolhive)** [![GitHub Repo stars](https://img.shields.io/github/stars/stacklok/toolhive?logo=github&label=&style=social)](https://github.com/stacklok/toolhive) - MCP server orchestrator for desktop, CLI, and Kubernetes Operator: discover and deploy servers in isolated containers with restricted permissions, manage secrets, use an optional egress proxy, auto-configure popular MCP clients (e.g., GitHub Copilot, Cursor), and manage at scale via CRDs/registry.
 
 ### Execution Sandboxing for Agent Code


### PR DESCRIPTION
Adds [ppcvote/misp-mcp-server](https://github.com/ppcvote/misp-mcp-server) to the Agent Tooling and MCP Security > Servers & Dev tooling section.

## Why this fits

MISP is the canonical open-source threat-intel platform. As SOC teams adopt Claude / Cursor / Cline for triage, a new attack surface emerges: **adversarial seeding** of MISP attributes (directly or via federated feeds) with prompt-injection payloads designed to hijack downstream LLM agents.

This MCP server bakes [`prompt-defense-audit`](https://github.com/ppcvote/prompt-defense-audit)'s `scanOutput()` into every MISP response, blocking high-risk patterns before they reach the LLM. Read-only by design (no event/attribute mutation tools) — LLM write access to a threat-intel platform would be a supply-chain compromise vector.

Tracks [MISP/MISP#10745](https://github.com/MISP/MISP/issues/10745). MIT licensed.

This is part of a broader thread on the same theme as [prompt-defense-audit (PR #63)](https://github.com/TalEliyahu/Awesome-AI-Security/pull/63) which you generously merged earlier. Thanks for maintaining the list 🙏