### PR TITLE
Add APort to AI guardrails resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - **[LlamaFirewall](https://github.com/meta-llama/PurpleLlama/tree/main/LlamaFirewall)** [![GitHub Repo stars](https://img.shields.io/github/stars/meta-llama/PurpleLlama?logo=github&label=&style=social)](https://github.com/meta-llama/PurpleLlama)
 - **[Code Shield](https://github.com/meta-llama/PurpleLlama/tree/main/CodeShield)** [![GitHub Repo stars](https://img.shields.io/github/stars/meta-llama/PurpleLlama?logo=github&label=&style=social)](https://github.com/meta-llama/PurpleLlama)
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** [![GitHub Repo stars](https://img.shields.io/github/stars/guardrails-ai/guardrails?logo=github&label=&style=social)](https://github.com/guardrails-ai/guardrails) - Runtime policy enforcement for LLM apps: compose input/output validators (PII, toxicity, jailbreak/PI, regex, competitor checks), then block/redact/rewrite/retry on fail; optional server mode; also supports structured outputs (Pydantic/function-calling).
+- **[APort](https://aport.io)** - Agent identity verification and policy enforcement for LLM tool calls, adding pre-action authorization guardrails before agents execute sensitive actions.
 
 ### Model Artifact Scanners
 *Analyze serialized model files for unsafe deserialization and embedded code; verify integrity/metadata and block or quarantine on fail.*


### PR DESCRIPTION
## Problem
APort is missing from this AI security resource list, even though it fits the agent runtime / guardrail category as a tool for agent identity and policy enforcement before sensitive tool calls execute.

## Summary
- Added APort with a one-sentence description.
- Placed it in the existing security/guardrail/runtime tooling section.

## Verification
- Ran git diff --check.
- Verified https://aport.io returns HTTP 200.

## Bounty
Related bounty issue: https://github.com/aporthq/aport-integrations/issues/19

Payment details if this PR qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y