### PR TITLE
Add AgentTier to Execution Sandboxing for Agent Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 
 - **[microsandbox](https://github.com/microsandbox/microsandbox)** [![GitHub Repo stars](https://img.shields.io/github/stars/microsandbox/microsandbox?logo=github&label=&style=social)](https://github.com/e2b-dev/E2B) - self-hosted microVM (libkrun) sandbox for untrusted AI/user code.
 
+- **[AgentTier](https://github.com/agenttier/agenttier)** [![GitHub Repo stars](https://img.shields.io/github/stars/agenttier/agenttier?logo=github&label=&style=social)](https://github.com/agenttier/agenttier) — Kubernetes-native sandbox runtime for AI coding agents. Each Sandbox CRD provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor RuntimeClass for kernel-level isolation, per-session ServiceAccount with no cluster permissions, and STS / per-session credential injection.
+
 ### Confidential & Verifiable Inference (PCC/TEEs)
 *Run AI models inside attested TEEs with end-to-end encryption, auditability, and unlinkable requests so prompts and outputs never leave the secure boundary.*
 


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) to **Tools → Execution Sandboxing for Agent Code**.

The section currently lists E2B and microsandbox. AgentTier sits next to them but takes a different approach: Kubernetes-native rather than microVM-based.

**Security posture:**

- Each `Sandbox` CR provisions a Pod + PVC + default-deny NetworkPolicy with always-on DNS and configurable allow rules.
- Optional gVisor RuntimeClass for kernel-level isolation of untrusted agent workloads.
- Per-session ServiceAccount with no cluster permissions.
- Hardened pod defaults: non-root user, read-only root filesystem, all capabilities dropped, `seccomp=RuntimeDefault`.
- Per-session credentials via STS AssumeRole or Kubernetes Secrets — never baked into the image.
- IRSA / Workload Identity for cloud-native credential attachment without long-lived secrets.
- Hierarchical (cluster → namespace) governance policies cap CPU/memory/storage, max sandboxes per user, allowed templates, approved image registries; violations return structured `policy_violation` errors.
- All released container images cosign keyless-signed, SBOMs (SPDX + CycloneDX) attached as OCI attestations.

License: Apache-2.0.

**Compliance with CONTRIBUTING.md:**

- ✅ Markdown-only single-line item.
- ✅ Format `[Name](url) — short description.` with em-dash.
- ✅ Neutral tone, no marketing language.
- ✅ Best section — same shape as E2B and microsandbox (sandbox-runtime tier).
- ✅ Star badge included matching the section's existing style.

Disclosure: I'm a contributor to AgentTier.
