### PR TITLE
Add Shellgate to Credential Isolation & Agent Access Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 *Prevent credential exfiltration by ensuring AI agents never access raw API keys; inject secrets at request time via proxy gateways.*
 
 - **[OneCLI](https://github.com/onecli/onecli)** [![GitHub Repo stars](https://img.shields.io/github/stars/onecli/onecli?logo=github&label=&style=social)](https://github.com/onecli/onecli) – Open-source credential vault for AI agents. Rust HTTP gateway intercepts agent requests and injects API credentials transparently; AES-256-GCM encryption, per-agent scoped tokens, full audit trail.
+- **[Shellgate](https://github.com/matthiastjong/shellgate)** [![GitHub Repo stars](https://img.shields.io/github/stars/matthiastjong/shellgate?logo=github&label=&style=social)](https://github.com/matthiastjong/shellgate) – A self-hosted security gateway that sits between AI agents and infrastructure — agents get scoped tokens, never see real credentials, and dangerous commands require human approval. MCP server with API gateway proxy, SSH execution guards, credential vault with blind-fill, and full audit trail.
 
 ### Prompt-Injection Detection & Mitigation
 *Detect and stop prompt-injection (direct/indirect) across inputs, context, and outputs; filter hostile content before it reaches tools or models.*


### PR DESCRIPTION
Adds [Shellgate](https://github.com/matthiastjong/shellgate) to the **Credential Isolation & Agent Access Control** section.

## What it is

Shellgate is a self-hosted security gateway (MCP server) that sits between AI agents and infrastructure. Agents get scoped tokens and never see real credentials; dangerous commands require human approval.

Key capabilities:
- **API gateway proxy** with credential injection — agents never see real secrets
- **SSH execution** with guard protection
- **Human-in-the-loop** approval for dangerous commands
- **Credential vault** with blind-fill
- **Full audit trail**
- **Prompt injection defense**

MIT licensed, actively maintained, 3 contributors.

## Why this section

Shellgate's core value proposition — preventing credential exfiltration by ensuring AI agents never access raw API keys — matches the section description exactly. It complements OneCLI by adding SSH execution guards and human-in-the-loop approval on top of credential isolation.

**No license/install changes.** Pure documentation addition.