### PR TITLE
Add SkilLock under Tool manifest/metadata validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 #### Tool manifest/metadata validators
 
 - **[mcp-scan](https://github.com/invariantlabs-ai/mcp-scan)** [![GitHub Repo stars](https://img.shields.io/github/stars/invariantlabs-ai/mcp-scan?logo=github&label=&style=social)](https://github.com/invariantlabs-ai/mcp-scan)
+- **[SkilLock](https://github.com/skills-lock/skil-lock)** [![GitHub Repo stars](https://img.shields.io/github/stars/skills-lock/skil-lock?logo=github&label=&style=social)](https://github.com/skills-lock/skil-lock) - Lockfile + GitHub Action that pins the parsed behavior surface (shell commands, URLs, file reads/writes, allowed tools) of Claude Code and Codex agent skills. Diffs the surface on every PR; catches "SKILL.md legitimately changed and now does something different" cases that hash pinning misses. Emits SARIF for GitHub Code Scanning. Apache 2.0.
 
 #### Agent Identity & Trust
 


### PR DESCRIPTION
Adds SkilLock to the "Tool manifest/metadata validators" subsection under "Agent Tooling and MCP Security."

SkilLock is an Apache 2.0 Go binary + GitHub Action that parses every SKILL.md (and Codex equivalent) in a repo, extracts the capability surface (shell commands, network URLs, file reads/writes, allowed tools, bundled scripts), commits it as `skills.lock`, and runs a capability-delta diff on every PR. Catches the family of "SKILL.md legitimately changed and now does something different" cases that hash pinning misses.

**Fit for "Tool manifest/metadata validators":** SkilLock validates the SKILL.md manifest format and extracts behavioral metadata. Same category as mcp-scan, but targets Claude Code / Codex skill manifests rather than MCP server manifests.

**Maintenance:** v0.1.2 released, last commit within the last week, public Marketplace listing at https://github.com/marketplace/actions/skillock-ci.

**Links:**

- Repo: https://github.com/skills-lock/skil-lock
- Worked example with real BLOCK on drift branch: https://github.com/skills-lock/example-claude-code-skills
- File-format spec (CC BY 4.0): https://github.com/skills-lock/skil-lock/blob/main/SPEC.md