### PR TITLE
Re-add AgentTier to Execution Sandboxing for Agent Code (lost in #71 merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - **[E2B](https://github.com/e2b-dev/E2B)** [![GitHub Repo stars](https://img.shields.io/github/stars/e2b-dev/E2B?logo=github&label=&style=social)](https://github.com/e2b-dev/E2B) - SDK + self-hostable infra to run untrusted, LLM-generated code in isolated cloud sandboxes (Firecracker microVMs).
 
 - **[microsandbox](https://github.com/microsandbox/microsandbox)** [![GitHub Repo stars](https://img.shields.io/github/stars/microsandbox/microsandbox?logo=github&label=&style=social)](https://github.com/e2b-dev/E2B) - self-hosted microVM (libkrun) sandbox for untrusted AI/user code.
+- **[AgentTier](https://github.com/agenttier/agenttier)** [![GitHub Repo stars](https://img.shields.io/github/stars/agenttier/agenttier?logo=github&label=&style=social)](https://github.com/agenttier/agenttier) — Kubernetes-native sandbox runtime for AI coding agents. Each Sandbox CRD provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor RuntimeClass for kernel-level isolation, per-session ServiceAccount with no cluster permissions, and STS / per-session credential injection.
 
 ### Confidential & Verifiable Inference (PCC/TEEs)
 *Run AI models inside attested TEEs with end-to-end encryption, auditability, and unlinkable requests so prompts and outputs never leave the secure boundary.*


### PR DESCRIPTION
Re-submission of [#71](https://github.com/TalEliyahu/Awesome-AI-Security/pull/71).

**Why a new PR:** #71 was marked as merged on 2026-05-28 by @TalEliyahu, but the AgentTier entry it added is **not present in the current `main`**. The PR's `merged_commit_sha` is `null` in the GitHub API response, and `grep -i agenttier README.md` against the live file returns zero matches. My read is that #71's anchor (`microsandbox` line) was reordered or rewritten upstream between submission (2026-05-14) and merge (2026-05-28), and the merge resolution dropped my added line silently while still marking the PR as merged. Reopening #71 isn't possible because `merged_at` is set, so this is a fresh PR with the same change re-applied against the current `main`.

**What this PR does:** inserts AgentTier under **Tools → Execution Sandboxing for Agent Code**, after `E2B` and `microsandbox`. Same content, same section, same format as #71 — just rebased against today's upstream.

**Compliance with CONTRIBUTING.md** (unchanged from #71):

- ✅ Markdown-only single-line item.
- ✅ Format `[Name](url) — short description.` with em-dash.
- ✅ Neutral tone, no marketing language.
- ✅ Best section — same shape as E2B and microsandbox (sandbox-runtime tier).
- ✅ Star badge included matching the section's existing style.

**Why it fits:** AgentTier is a Kubernetes-native sandbox runtime for AI coding agents. Each `Sandbox` CR provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor RuntimeClass for kernel-level isolation, a per-session ServiceAccount with no cluster permissions, and per-session credential injection (STS / Secrets Manager). Apache-2.0.

Disclosure: I'm a contributor to AgentTier.
