### PR TITLE
add authsome under Credential Isolation &amp; Agent Access Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 *Prevent credential exfiltration by ensuring AI agents never access raw API keys; inject secrets at request time via proxy gateways.*
 
 - **[OneCLI](https://github.com/onecli/onecli)** [![GitHub Repo stars](https://img.shields.io/github/stars/onecli/onecli?logo=github&label=&style=social)](https://github.com/onecli/onecli) – Open-source credential vault for AI agents. Rust HTTP gateway intercepts agent requests and injects API credentials transparently; AES-256-GCM encryption, per-agent scoped tokens, full audit trail.
+- **[authsome](https://github.com/agentrhq/authsome)** [![GitHub Repo stars](https://img.shields.io/github/stars/agentrhq/authsome?logo=github&label=&style=social)](https://github.com/agentrhq/authsome) – Local credential broker for AI agents. Python CLI with encrypted local vault and a local HTTPS proxy on loopback that injects OAuth2 access tokens and API keys at request time so the agent's process env never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key), browser PKCE / device code flows, background token refresh, no SaaS dependency.
 
 ### Prompt-Injection Detection & Mitigation
 *Detect and stop prompt-injection (direct/indirect) across inputs, context, and outputs; filter hostile content before it reaches tools or models.*


### PR DESCRIPTION
hey, opening this to add authsome under Credential Isolation & Agent Access Control.

the section description ("Prevent credential exfiltration by ensuring AI agents never access raw API keys; inject secrets at request time via proxy gateways") is exactly authsome's elevator pitch. slotted right after OneCLI since they're direct category peers (different stack — authsome is Python, OneCLI is Rust — and different threat model — authsome is local-first single-user, OneCLI has per-agent scoping for multi-agent fleets).

what authsome is: log in once via OAuth2 (browser PKCE or device code) or API key, encrypted local vault stores credentials, a local HTTPS proxy on loopback injects credentials into outbound provider requests so the agent's process env never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe. background token refresh, no SaaS dependency.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
pypi: https://pypi.org/project/authsome/ (0.3.2)