### PR TITLE
Add Confidential AI under Confidential & Verifiable Inference (PCC/TEEs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - **[Phala](https://phala.com/)** ([Docs](https://docs.phala.network/) • [GitHub](https://github.com/Phala-Network/phala-cloud)) — Confidential AI cloud platform running LLMs and AI workloads in GPU TEEs (NVIDIA H100/H200). Features hardware attestation, verifiable inference, and Docker-based deployment with zero code changes. Supports both CPU TEE (Intel TDX) and GPU TEE for confidential AI at scale.
 - **[dstack](https://github.com/dstack-TEE/dstack)** [![GitHub Repo stars](https://img.shields.io/github/stars/dstack-TEE/dstack?logo=github&label=&style=social)](https://github.com/dstack-TEE/dstack) — Open-source SDK for building TEE-based confidential applications. Provides Docker-to-TEE deployment, remote attestation, secure key management, and TLS termination inside enclaves. Works with Intel TDX and NVIDIA GPU TEEs.
 - **[OpenPCC](https://github.com/openpcc/openpcc) [![GitHub Repo stars](https://img.shields.io/github/stars/openpcc/openpcc?style=social)](https://github.com/openpcc/openpcc)** — Open-source framework for provably private AI inference (encrypted streaming, hardware attestation, unlinkable requests), inspired by Apple's PCC and deployable on your own infra. 
+- **[Confidential AI](https://confidential.ai)** — Private, verifiable AI inference, agents, and training. Hosted and self-hosted.
 
 ### Gateways & Policy Proxies
 *Centralize auth, quotas/rate limits, cost caps, egress/DLP filters, and guardrail orchestration across all model/providers.*


### PR DESCRIPTION
Adds Confidential AI (https://confidential.ai) to the **Tools → Confidential & Verifiable Inference (PCC/TEEs)** subsection, alongside Phala, dstack, and OpenPCC.

Confidential AI's Confidential Agents API runs end-to-end private OpenClaw agents with confidential inference inside hardware-attested AMD SEV-SNP TEEs, keeping prompts, data, and model I/O within the secure boundary.

Entry matches the subsection's formatting and neutral tone:

```
- **[Confidential AI](https://confidential.ai)** — Confidential Agents API running end-to-end private OpenClaw agents with confidential inference inside hardware-attested AMD SEV-SNP TEEs.
```
