### PR TITLE
Add GTK Cyber to Training (Bespoke)

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Adversarial prompt datasets-both text-only and multimodal-designed to bypass saf
 
 ### Bespoke
 - [Trail of Bits - AI/ML Security & Safety Training](https://www.trailofbits.com/services/software-assurance/ai-ml/) - Courses on AI failure modes, adversarial attacks, data provenance, pipeline threats, and mitigation.
+- [GTK Cyber - AI Red-Teaming & AI Security Training](https://gtkcyber.com/courses) - Hands-on, instructor-led courses on AI red-teaming, prompt injection, adversarial ML, and applying AI to detection and threat hunting; taught at Black Hat USA and delivered as private on-site training.
 
 ---
 


### PR DESCRIPTION
Adds GTK Cyber to the Training → Bespoke section, alongside the existing Trail of Bits entry.

GTK Cyber runs hands-on, instructor-led AI red-teaming and AI security training (prompt injection, jailbreaks, adversarial ML, AI for detection and threat hunting), taught at Black Hat USA and HITB and delivered as private on-site training. One-line format per CONTRIBUTING.md.

Disclosure: I'm affiliated with GTK Cyber.