### PR TITLE
Add hego.red to Testing, Evaluation & Red Teaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - [OWASP - LLM Exploit Generation](https://genai.owasp.org/resource/owasp-llm-exploit-generation-v1-0-pdf/)
 - [CSA - Agentic AI Red Teaming Guide](https://cloudsecurityalliance.org/artifacts/agentic-ai-red-teaming-guide)
 - [OWASP AI Testing Guide](https://github.com/OWASP/www-project-ai-testing-guide) [![GitHub stars](https://img.shields.io/github/stars/OWASP/www-project-ai-testing-guide?style=social)](https://github.com/OWASP/www-project-ai-testing-guide) – Guide that provides comprehensive, structured methodologies and best practices for testing artificial intelligence systems.
+- [hego.red](https://hego.red/) - Practical, hands-on AI/LLM red teaming guide: prompt injection, jailbreaks, indirect injection, RAG, agents, methodology, and worked labs.
 
 ### Implementation Guides & Patterns
 


### PR DESCRIPTION
Adds hego.red, a free single-page practical guide to AI/LLM red teaming: prompt injection, jailbreaks, indirect injection, RAG poisoning, agent and tool attacks, a full methodology mapped to the OWASP LLM Top 10 and MITRE ATLAS, plus worked labs. No ads, no tracking, no signup. Added under Testing, Evaluation & Red Teaming.