### PR TITLE
Add Adrian to Prompt-Injection Detection & Mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 ### Prompt-Injection Detection & Mitigation
 *Detect and stop prompt-injection (direct/indirect) across inputs, context, and outputs; filter hostile content before it reaches tools or models.*
 
-- *(none from your current list yet)* -
-- 
+- **[Adrian](https://github.com/secureagentics/Adrian)** [![GitHub Repo stars](https://img.shields.io/github/stars/secureagentics/Adrian?logo=github&label=&style=social)](https://github.com/secureagentics/Adrian) - Open-source, AARM-aligned runtime detection/mitigation: analyzes agent tool calls and reasoning traces to catch prompt injection and out-of-remit behavior, with in-flight block mode. LangChain/LangGraph/OpenAI Agents SDK; self-hostable offline.
+
 ### Jailbreak & Policy Enforcement (Guardrails)
 *Enforce safety policies and block jailbreaks at runtime via rules/validators/DSLs, with optional human-in-the-loop for sensitive actions.*
 


### PR DESCRIPTION
Adds **Adrian** under *Tools → Prompt-Injection Detection & Mitigation* (the section was empty).

Adrian is an open-source, AARM-aligned runtime detection/mitigation tool: it analyses agent tool calls and reasoning traces to catch prompt injection and out-of-remit behaviour, with in-flight block mode. LangChain/LangGraph/OpenAI Agents SDK; self-hostable offline; Apache-2.0.

It could also sit under "Jailbreak & Policy Enforcement (Guardrails)" — happy to move if you prefer. **Disclosure:** I'm a maintainer (Secure Agentics).
