### PR TITLE
Add SecuredAI for client-side prompt DLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 
 - **[Presidio](https://github.com/microsoft/presidio)** [![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/presidio?logo=github&label=&style=social)](https://github.com/microsoft/presidio) - PII/PHI detection & redaction for text, images, and structured data; use as a pre/post-LLM DLP filter and for dataset sanitization.
 
+- **[SecuredAI](https://securedai.com/)** - Client-side prompt DLP: detects and masks PII/PHI in prompts before they reach the model (OpenAI/DeepSeek) and restores originals locally via a zero-knowledge vault; commercial.
+
 ### Monitoring, Logging & Anomaly Detection
 *Collect AI-specific security logs/signals; detect abuse patterns (PI/jailbreak/leakage), enrich alerts, and support forensics.*
 


### PR DESCRIPTION
Adds **SecuredAI** (https://securedai.com) to the *Sensitive Data Leak Prevention (DLP for AI)* section.

SecuredAI is a client-side prompt DLP layer: it detects and masks PII/PHI in prompts before they reach the model (OpenAI/DeepSeek), then restores the original values locally via a zero-knowledge vault, so sensitive data never leaves the user's environment. Flagged as commercial to match how other entries are described.

Single-line addition placed after the Presidio entry, formatted to match. Thanks for maintaining the list.