### PR TITLE
Add Darkmoon to Goal-directed agent attack tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - **[CAI - Cybersecurity AI](https://github.com/aliasrobotics/cai)** [![GitHub Repo stars](https://img.shields.io/github/stars/aliasrobotics/cai?logo=github&label=&style=social)](https://github.com/aliasrobotics/cai) 
 - **[hackingBuddyGPT](https://github.com/ipa-lab/hackingBuddyGPT)** [![GitHub Repo stars](https://img.shields.io/github/stars/ipa-lab/hackingBuddyGPT?logo=github&label=&style=social)](https://github.com/ipa-lab/hackingBuddyGPT)
 - **[HexStrike AI](https://github.com/0x4m4/hexstrike-ai)** [![GitHub Repo stars](https://img.shields.io/github/stars/0x4m4/hexstrike-ai?logo=github&label=&style=social)](https://github.com/0x4m4/hexstrike-ai)
+- **[Darkmoon](https://github.com/ASCIT31/Dark-Moon)** [![GitHub Repo stars](https://img.shields.io/github/stars/ASCIT31/Dark-Moon?logo=github&label=&style=social)](https://github.com/ASCIT31/Dark-Moon) - Open source engine for autonomous AI penetration testing that orchestrates 80+ offensive tools through Markdown playbooks and agentic reasoning over MCP, with a command and raw output evidence trail for every finding across web, cloud, Active Directory, Kubernetes and API.
 - **[Nebula](https://github.com/berylliumsec/nebula)** [![GitHub Repo stars](https://img.shields.io/github/stars/berylliumsec/nebula?logo=github&label=&style=social)](https://github.com/berylliumsec/nebula)
 
 #### CI pipelines & regression gates


### PR DESCRIPTION
This adds Darkmoon to Tools > Red-Teaming Harnesses > Goal-directed agent attack tasks, next to PentestGPT, CAI, HexStrike AI and Nebula. Darkmoon is an open source (GPL-3.0) autonomous AI penetration testing engine that orchestrates 80+ offensive tools via Markdown playbooks and MCP with an evidence trail for every finding. https://github.com/ASCIT31/Dark-Moon