### PR TITLE
Add Deployer AI Risk Register (DARR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 - [CSA - AI Model Risk Management Framework](https://cloudsecurityalliance.org/artifacts/ai-model-risk-management-framework)
 - [NIST - Artificial Intelligence Risk Management Framework: Generative Artificial Intelligence Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
 - [AI Security Shared Responsibility Model](https://github.com/mikeprivette/ai-security-shared-responsibility) [![GitHub Repo stars](https://img.shields.io/github/stars/mikeprivette/ai-security-shared-responsibility?logo=github&label=&style=social)](https://github.com/mikeprivette/ai-security-shared-responsibility)
+- [Deployer AI Risk Register (DARR)](https://www.airiskdeployer.org) - Canonical AI risks for organizations that deploy AI systems, consolidated from the MIT AI Risk Repository and crosswalked to ISO/IEC 42001, the EU AI Act, and MITRE ATLAS. Open data (CC BY 4.0); [source on GitHub](https://github.com/Myr-Aya/darr-deployer-ai-risk-register).
 
 ### Controls & Verification Standards
 - [OWASP - LLM Security Verification Standard (LLMSVS)](https://github.com/OWASP/www-project-llm-verification-standard) [![GitHub Repo stars](https://img.shields.io/github/stars/OWASP/www-project-llm-verification-standard?logo=github&label=&style=social)](https://github.com/OWASP/www-project-llm-verification-standard)


### PR DESCRIPTION
Adds the Deployer AI Risk Register (DARR) under Governance & Management Frameworks, next to NIST AI RMF and ISO/IEC 42001, which DARR crosswalks to. One line, neutral tone, canonical link, per CONTRIBUTING.

DARR is an open catalogue of canonical AI risks for organizations that deploy AI systems, consolidated from the MIT AI Risk Repository and crosswalked to ISO/IEC 42001, the EU AI Act, and MITRE ATLAS. CC BY 4.0; https://www.airiskdeployer.org. Happy to move it to the taxonomies foundations section if you prefer.