### PR TITLE
Add AgentSentry Gateway to Gateways & Policy Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 ### Gateways & Policy Proxies
 *Centralize auth, quotas/rate limits, cost caps, egress/DLP filters, and guardrail orchestration across all model/providers.*
 
+- **[AgentSentry Gateway](https://github.com/akav-labs/agentsentry-gateway)** [![GitHub Repo stars](https://img.shields.io/github/stars/akav-labs/agentsentry-gateway?logo=github&label=&style=social)](https://github.com/akav-labs/agentsentry-gateway) – open-source (Apache-2.0) OpenAI-compatible proxy in Rust that scans requests and responses (including streaming) for secret/PII leakage, prompt injection, and jailbreaks; blocks at the egress and folds Unicode homoglyphs to resist look-alike evasion.
 - **[Cerbos](https://github.com/cerbos/cerbos)** [![GitHub Repo stars](https://img.shields.io/github/stars/cerbos/cerbos?logo=github&label=&style=social)](https://github.com/cerbos/cerbos) – open-source, policy-based authorization layer for fine-grained controls in MCP servers, RAG pipelines, and other agentic systems.
 
 ### Code Review


### PR DESCRIPTION
Adds [AgentSentry Gateway](https://github.com/akav-labs/agentsentry-gateway) under **Tools → Gateways & Policy Proxies** — an open-source (Apache-2.0) OpenAI-compatible security proxy in Rust that scans LLM requests and responses (including SSE streaming) for secret/PII leakage, prompt injection, and jailbreaks, and blocks violations at the egress.

Disclosure: this is our project. Entry follows the section's existing format (stars badge + short neutral note); placed alphabetically. Background write-up on the detection engineering, if useful for review: https://dev.to/akavlabs_69/i-red-teamed-my-own-llm-security-gateway-in-four-passes-heres-every-gap-i-found-5cl9