### PR TITLE
Add halo-record (tamper-evident agent runtime records)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 ### Monitoring, Logging & Anomaly Detection
 *Collect AI-specific security logs/signals; detect abuse patterns (PI/jailbreak/leakage), enrich alerts, and support forensics.*
 
+- **[halo-record](https://github.com/bkuan001/halo-record)** [![GitHub Repo stars](https://img.shields.io/github/stars/bkuan001/halo-record?logo=github&label=&style=social)](https://github.com/bkuan001/halo-record) - Tamper-evident records of AI agent actions (tool calls, model calls, data access): hash-chained append-only logs anyone can re-verify without trusting the producer; self-verifying HTML reports, date-windowed audit exports, deterministic policy checks (AIUC-1, OWASP Agentic Top 10). Zero-dependency Python + TypeScript.
+
 - **[LangKit](https://github.com/whylabs/langkit)** [![GitHub Repo stars](https://img.shields.io/github/stars/whylabs/langkit?logo=github&label=&style=social)](https://github.com/whylabs/langkit) - LLM observability metrics toolkit (whylogs-compatible): prompt-injection/jailbreak similarity, PII patterns, hallucination/consistency, relevance, sentiment/toxicity, readability.
 
 - **[Alibi Detect](https://github.com/SeldonIO/alibi-detect)** [![GitHub Repo stars](https://img.shields.io/github/stars/SeldonIO/alibi-detect?logo=github&label=&style=social)](https://github.com/SeldonIO/alibi-detect) - Production drift/outlier/adversarial detection for tabular, text, images, and time series; online/offline detectors with TF/PyTorch backends; returns scores, thresholds, and flags for alerting.


### PR DESCRIPTION
Adds halo-record under Tools → Monitoring, Logging & Anomaly Detection: open-source, tamper-evident records of what AI agents actually do — hash-chained append-only logs that anyone can re-verify without trusting the producer, self-verifying HTML reports, date-windowed audit exports, and deterministic policy checks against AIUC-1 and the OWASP Agentic Top 10. Apache-2.0, zero runtime dependencies, Python + TypeScript. The forensics/evidence angle fits this subsection's scope note; happy to move it if you prefer another home.