### PR TITLE
[tools] add memory-blackbox to Vector/Memory Store Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Curated resources, research, and tools for securing AI systems. Managed by [AISe
 ### Vector/Memory Store Security
 *Harden RAG memory: isolate namespaces, sanitize queries/content, detect poisoning/outliers, and prevent secret/PII retention.*
 
-- *(none from your current list yet)*
+- [memory-blackbox — @lavkumarv](https://github.com/lavkumarv/memory-blackbox) [![GitHub Repo stars](https://img.shields.io/github/stars/lavkumarv/memory-blackbox?logo=github&label=&style=social)](https://github.com/lavkumarv/memory-blackbox) — Tamper-evident provenance ledger for agent memory reads and writes; traces an action to its source memory, computes blast radius, and rolls back.
 
 ### Data/Model Poisoning Defenses
 *Detect and mitigate dataset/model poisoning and backdoors; validate training/fine-tuning integrity and prune suspicious behaviors.*


### PR DESCRIPTION
Adds one entry to **Vector/Memory Store Security**, which is currently empty.

[memory-blackbox](https://github.com/lavkumarv/memory-blackbox) is an Apache-2.0 Python toolkit that captures every AI-agent memory read and write into an append-only ledger (BLAKE3 hash chain, Ed25519 signatures, signed Merkle checkpoints) plus a provenance DAG, then traces a harmful agent action back to the memory that caused it, computes the forward closure of a poisoned source, and quarantines it by appending rather than deleting.

Scope note for accuracy: it is **post-incident reconstruction, not runtime prevention** — it runs underneath guardrails rather than replacing them. Early development (0.1.0 on PyPI).

Style checklist per `AGENTS.md`:
- One-line entry, en dash separator, stars badge
- Neutral description, 22 words
- Existing canonical section, no new section invented
- No decorative graphics
